### PR TITLE
Feature/v74 changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,6 @@ pipeline {
 				}
 			}
 		}
-		/*
 		// This stage backs up the gk_central database before it is modified.
 		stage('Setup: Back up Curator gk_central DB'){
 			steps{
@@ -61,7 +60,6 @@ pipeline {
 				}
 			}
 		}
-		*/
 		// This stage builds the jar file using maven.
 		stage('Setup: Build jar files'){
 			steps{
@@ -90,7 +88,6 @@ pipeline {
 				}
 			}
 		}
-		/*
 		// This stage creates a new 'release_previous' database from the 'release_current' database.
 		stage('Post: Create release_previous from release_current'){
 			steps{
@@ -114,7 +111,6 @@ pipeline {
 				}
 			}
 		}
-		*/
 		// QA for ensuring StableIdentifier instances are proper.
 		stage('Post: StableIdentifier QA'){
 			steps{
@@ -127,7 +123,6 @@ pipeline {
 				}
 			}
 		}
-		/*
 		// This stage backs up the gk_central and slice_current databases after they have been modified.
 		stage('Post: Backup DBs'){
 			steps{
@@ -162,6 +157,5 @@ pipeline {
 				}
 			}
 		}
-		*/
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,18 @@ pipeline {
 		}
 		// This stage creates a new 'release_current' database from the freshly updated 'slice_current' database.
 		// This will be the primary database used throughout release from here.
+		stage('Post: Create release_previous from release_current'){
+			steps{
+				script{
+					withCredentials([usernamePassword(credentialsId: 'mySQLUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]) {
+						sh "mysql -u$user -p$pass -e \'drop database if exists ${env.RELEASE_PREVIOUS}; create database ${env.RELEASE_PREVIOUS}\'"
+						sh "mysqldump --opt -u$user -p$pass ${env.RELEASE_CURRENT} | mysql -u$user -p$pass ${env.RELEASE_PREVIOUS}"
+					}
+				}
+			}
+		}
+		// This stage creates a new 'release_current' database from the freshly updated 'slice_current' database.
+		// This will be the primary database used throughout release from here.
 		stage('Post: Create release_current from slice_current'){
 			steps{
 				script{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 // This Jenkinsfile is used by Jenkins to run the UpdateStableIdentifiers step of Reactome's release.
 // It requires that the ConfirmReleaseConfigs step has been run successfully before it can be run.
 
-import groovy.json.JsonSlurper
 import org.reactome.release.jenkins.utilities.Utilities
 
 // Shared library maintained at 'release-jenkins-utils' repository.
@@ -26,7 +25,7 @@ pipeline {
 				script{
 					withCredentials([usernamePassword(credentialsId: 'mySQLUsernamePassword', passwordVariable: 'pass', usernameVariable: 'user')]){
 						
-						// Replace 'slice_previous' db with snapshot slice DB from S3.
+						// Replace 'slice_previous' db with 'snapshot' slice DB from S3.
 						def previousReleaseVersion = utils.getPreviousReleaseVersion()
 						def slicePreviousSnapshotDump = "${env.SLICE_TEST_DB}_${previousReleaseVersion}_snapshot.dump.gz"
 						// Retrieve previous releases' snapshot slice DB from S3.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,6 @@ pipeline {
 				}
 			}
 		}
-		/*
 		// This stage moves 'slice_current' database to 'slice_previous', and then moves 'slice_test' to 'slice_current'.
 		// It also saves the slice_test dump as a snapshot, to be used in the next release.
 		stage('Setup: Rotate slice DBs'){
@@ -49,6 +48,7 @@ pipeline {
 				}
 			}
 		}
+		/*
 		// This stage backs up the gk_central database before it is modified.
 		stage('Setup: Back up Curator gk_central DB'){
 			steps{
@@ -61,6 +61,7 @@ pipeline {
 				}
 			}
 		}
+		*/
 		// This stage builds the jar file using maven.
 		stage('Setup: Build jar files'){
 			steps{
@@ -89,7 +90,7 @@ pipeline {
 				}
 			}
 		}
-		*/
+		/*
 		// This stage creates a new 'release_previous' database from the 'release_current' database.
 		stage('Post: Create release_previous from release_current'){
 			steps{
@@ -113,6 +114,7 @@ pipeline {
 				}
 			}
 		}
+		*/
 		// QA for ensuring StableIdentifier instances are proper.
 		stage('Post: StableIdentifier QA'){
 			steps{
@@ -125,6 +127,7 @@ pipeline {
 				}
 			}
 		}
+		/*
 		// This stage backs up the gk_central and slice_current databases after they have been modified.
 		stage('Post: Backup DBs'){
 			steps{
@@ -159,5 +162,6 @@ pipeline {
 				}
 			}
 		}
+		*/
 	}
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
 				}
 			}
 		}
+		/*
 		// This stage moves 'slice_current' database to 'slice_previous', and then moves 'slice_test' to 'slice_current'.
 		// It also saves the slice_test dump as a snapshot, to be used in the next release.
 		stage('Setup: Rotate slice DBs'){
@@ -88,8 +89,8 @@ pipeline {
 				}
 			}
 		}
-		// This stage creates a new 'release_current' database from the freshly updated 'slice_current' database.
-		// This will be the primary database used throughout release from here.
+		*/
+		// This stage creates a new 'release_previous' database from the 'release_current' database.
 		stage('Post: Create release_previous from release_current'){
 			steps{
 				script{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,18 +104,16 @@ pipeline {
 						// Take existing 'release_current' DB and replace 'release_previous' with it.
 						// TODO this should come from S3 final DB resting place.
 						def previousReleaseVersion = utils.getPreviousReleaseVersion()
-						def previousReleaseCurrentFinalFilename = "${env.RELEASE_CURRENT_DB}_${previousReleaseVersion}_final.dump"
-						utils.takeDatabaseDump("${env.RELEASE_CURRENT_DB}", "${previousReleaseCurrentFinalFilename}", "${env.RELEASE_SERVER}")
-				      		sh "gzip ${previousReleaseCurrentFinalFilename}"
-						utils.replaceDatabase("${env.RELEASE_PREVIOUS_DB}", "${previousReleaseCurrentFinalFilename}.gz")
-						sh "rm ${previousReleaseCurrentFinalFilename}.gz"
+						def releaseCurrentDBToBeReplacedDumpName = "${env.RELEASE_CURRENT_DB}_${previousReleaseVersion}_final.dump"
+						utils.takeDatabaseDump("${env.RELEASE_CURRENT_DB}", "${releaseCurrentDBToBeReplacedDumpName}", "${env.RELEASE_SERVER}")
+				      		sh "gzip ${releaseCurrentDBToBeReplacedDumpName}"
+						utils.replaceDatabase("${env.RELEASE_PREVIOUS_DB}", "${releaseCurrentDBToBeReplacedDumpName}.gz")
+						sh "rm ${releaseCurrentDBToBeReplacedDumpName}.gz"
 						
 						// Replace 'release_current' DB with updated 'slice_current' DB.
 				    		def releaseVersion = utils.getReleaseVersion()
-						def sliceCurrentDump = "${env.SLICE_CURRENT_DB}_${releaseVersion}.dump"
-						def databaseDumpFilename = utils.takeDatabaseDumpAndGzip("${env.SLICE_CURRENT_DB}", "update_stable_ids", "after", "${env.RELEASE_SERVER}")
-			            		sh "echo ${databaseDumpFilename}"
-				 		utils.replaceDatabase("${env.RELEASE_CURRENT_DB}", "${databaseDumpFilename}")
+						def sliceCurrentAfterStableIdUpdateDump = utils.takeDatabaseDumpAndGzip("${env.SLICE_CURRENT_DB}", "update_stable_ids", "after", "${env.RELEASE_SERVER}")
+				 		utils.replaceDatabase("${env.RELEASE_CURRENT_DB}", "${sliceCurrentAfterStableIdUpdateDump}")
 					}
 				}
 			}

--- a/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
+++ b/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
@@ -68,7 +68,7 @@ public class StableIdentifierUpdater {
 					}
 				} else {
 					if (sliceInstanceModified.size() < prevSliceInstanceModified.size()) {
-						logger.warn(sliceInstance + " in current release has less modification instances than previous release");
+						logger.fatal(sliceInstance + " in current release has less modification instances than previous release");
 						throw new IllegalStateException("Found instance with less modification instances than in previous release -- terminating");
 					}
 					notIncrementedCount++;

--- a/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
+++ b/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
@@ -21,8 +21,8 @@ public class StableIdentifierUpdater {
 		logger.info("Generating InstanceEdits for " + dbaSlice.getDBName() + " and " + dbaGkCentral.getDBName());
 		// Instance Edits for test_slice and gk_central
 		String creatorName = "org.reactome.release.updateStableIds";
-//		GKInstance sliceIE = InstanceEditUtils.createInstanceEdit(dbaSlice, personId, creatorName);
-//		GKInstance gkCentralIE = InstanceEditUtils.createInstanceEdit(dbaGkCentral, personId, creatorName);
+		GKInstance sliceIE = InstanceEditUtils.createInstanceEdit(dbaSlice, personId, creatorName);
+		GKInstance gkCentralIE = InstanceEditUtils.createInstanceEdit(dbaGkCentral, personId, creatorName);
 
 		// At time of writing (December 2018), test_slice is a non-transactional database. This check has been put in place as a safety net in case that changes.
 		if (dbaSlice.supportsTransactions()) {
@@ -58,8 +58,8 @@ public class StableIdentifierUpdater {
 					// Make sure StableIdentifier instance exists
 					if (sliceInstance.getAttributeValue(stableIdentifier) != null && gkCentralInstance.getAttributeValue(stableIdentifier) != null) {
 						logger.info("\tIncrementing " + sliceInstance.getAttributeValue(stableIdentifier));
-//						incrementStableIdentifier(sliceInstance, dbaSlice, sliceIE);
-//						incrementStableIdentifier(gkCentralInstance, dbaGkCentral, gkCentralIE);
+						incrementStableIdentifier(sliceInstance, dbaSlice, sliceIE);
+						incrementStableIdentifier(gkCentralInstance, dbaGkCentral, gkCentralIE);
 						incrementedCount++;
 					} else if (sliceInstance.getAttributeValue(stableIdentifier) == null){
 						logger.warn(sliceInstance + ": could not locate StableIdentifier instance");
@@ -68,8 +68,8 @@ public class StableIdentifierUpdater {
 					}
 				} else {
 					if (sliceInstanceModified.size() < prevSliceInstanceModified.size()) {
-						logger.warn("FATAL: " + sliceInstance + " in current release has less modification instances than previous release");
-//						throw new IllegalStateException("Found instance with less modification instances than in previous release -- terminating");
+						logger.warn(sliceInstance + " in current release has less modification instances than previous release");
+						throw new IllegalStateException("Found instance with less modification instances than in previous release -- terminating");
 					}
 					notIncrementedCount++;
 				}
@@ -83,10 +83,10 @@ public class StableIdentifierUpdater {
 
 						if (releaseStatusString == null || !releaseStatusString.equals(updated)) {
 							logger.info("Updating release status for " + sliceInstance);
-//							sliceInstance.addAttributeValue(releaseStatus, updated);
-//							sliceInstance.addAttributeValue(modified, sliceIE);
-//							dbaSlice.updateInstanceAttribute(sliceInstance, releaseStatus);
-//							dbaSlice.updateInstanceAttribute(sliceInstance, modified);
+							sliceInstance.addAttributeValue(releaseStatus, updated);
+							sliceInstance.addAttributeValue(modified, sliceIE);
+							dbaSlice.updateInstanceAttribute(sliceInstance, releaseStatus);
+							dbaSlice.updateInstanceAttribute(sliceInstance, modified);
 						} else {
 							logger.info("StableIdentifer has already been updated during this release");
 						}
@@ -99,11 +99,11 @@ public class StableIdentifierUpdater {
 			}
 		}
 		// TODO: Update test_slice after gkCentral has been successfully updated
-//		if (dbaSlice.supportsTransactions()) {
-//			dbaSlice.commit();
-//		}
+		if (dbaSlice.supportsTransactions()) {
+			dbaSlice.commit();
+		}
 		logger.info("Commiting all changes in " + dbaGkCentral.getDBName());
-//		dbaGkCentral.commit();
+		dbaGkCentral.commit();
 		logger.info(incrementedCount + " Stable Identifiers were updated");
 		logger.info(notIncrementedCount + " were not updated");
 		logger.info("UpdateStableIdentifiers step has finished");
@@ -121,9 +121,9 @@ public class StableIdentifierUpdater {
 		stableIdentifierInst.setDisplayName(id + "." + newIdentifierVersion);
 		Collection<GKInstance> modifiedInstances = (Collection<GKInstance>) stableIdentifierInst.getAttributeValuesList(modified);
 		stableIdentifierInst.addAttributeValue(modified, instanceEdit);
-//		dba.updateInstanceAttribute(stableIdentifierInst, identifierVersion);
-//		dba.updateInstanceAttribute(stableIdentifierInst, _displayName);
-//		dba.updateInstanceAttribute(stableIdentifierInst, modified);
+		dba.updateInstanceAttribute(stableIdentifierInst, identifierVersion);
+		dba.updateInstanceAttribute(stableIdentifierInst, _displayName);
+		dba.updateInstanceAttribute(stableIdentifierInst, modified);
 	}
 
 	// Checks via the 'releaseStatus', 'revised', and 'reviewed' attributes if this instance has been updated since last release.

--- a/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
+++ b/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
@@ -68,7 +68,7 @@ public class StableIdentifierUpdater {
 					}
 				} else {
 					if (sliceInstanceModified.size() < prevSliceInstanceModified.size()) {
-						logger.fatal(sliceInstance + " in current release has less modification instances than previous release");
+						logger.warn("FATAL: " + sliceInstance + " in current release has less modification instances than previous release");
 //						throw new IllegalStateException("Found instance with less modification instances than in previous release -- terminating");
 					}
 					notIncrementedCount++;

--- a/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
+++ b/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
@@ -21,8 +21,8 @@ public class StableIdentifierUpdater {
 		logger.info("Generating InstanceEdits for " + dbaSlice.getDBName() + " and " + dbaGkCentral.getDBName());
 		// Instance Edits for test_slice and gk_central
 		String creatorName = "org.reactome.release.updateStableIds";
-		GKInstance sliceIE = InstanceEditUtils.createInstanceEdit(dbaSlice, personId, creatorName);
-		GKInstance gkCentralIE = InstanceEditUtils.createInstanceEdit(dbaGkCentral, personId, creatorName);
+//		GKInstance sliceIE = InstanceEditUtils.createInstanceEdit(dbaSlice, personId, creatorName);
+//		GKInstance gkCentralIE = InstanceEditUtils.createInstanceEdit(dbaGkCentral, personId, creatorName);
 
 		// At time of writing (December 2018), test_slice is a non-transactional database. This check has been put in place as a safety net in case that changes.
 		if (dbaSlice.supportsTransactions()) {
@@ -58,8 +58,8 @@ public class StableIdentifierUpdater {
 					// Make sure StableIdentifier instance exists
 					if (sliceInstance.getAttributeValue(stableIdentifier) != null && gkCentralInstance.getAttributeValue(stableIdentifier) != null) {
 						logger.info("\tIncrementing " + sliceInstance.getAttributeValue(stableIdentifier));
-						incrementStableIdentifier(sliceInstance, dbaSlice, sliceIE);
-						incrementStableIdentifier(gkCentralInstance, dbaGkCentral, gkCentralIE);
+//						incrementStableIdentifier(sliceInstance, dbaSlice, sliceIE);
+//						incrementStableIdentifier(gkCentralInstance, dbaGkCentral, gkCentralIE);
 						incrementedCount++;
 					} else if (sliceInstance.getAttributeValue(stableIdentifier) == null){
 						logger.warn(sliceInstance + ": could not locate StableIdentifier instance");
@@ -69,7 +69,7 @@ public class StableIdentifierUpdater {
 				} else {
 					if (sliceInstanceModified.size() < prevSliceInstanceModified.size()) {
 						logger.fatal(sliceInstance + " in current release has less modification instances than previous release");
-						throw new IllegalStateException("Found instance with less modification instances than in previous release -- terminating");
+//						throw new IllegalStateException("Found instance with less modification instances than in previous release -- terminating");
 					}
 					notIncrementedCount++;
 				}
@@ -83,10 +83,10 @@ public class StableIdentifierUpdater {
 
 						if (releaseStatusString == null || !releaseStatusString.equals(updated)) {
 							logger.info("Updating release status for " + sliceInstance);
-							sliceInstance.addAttributeValue(releaseStatus, updated);
-							sliceInstance.addAttributeValue(modified, sliceIE);
-							dbaSlice.updateInstanceAttribute(sliceInstance, releaseStatus);
-							dbaSlice.updateInstanceAttribute(sliceInstance, modified);
+//							sliceInstance.addAttributeValue(releaseStatus, updated);
+//							sliceInstance.addAttributeValue(modified, sliceIE);
+//							dbaSlice.updateInstanceAttribute(sliceInstance, releaseStatus);
+//							dbaSlice.updateInstanceAttribute(sliceInstance, modified);
 						} else {
 							logger.info("StableIdentifer has already been updated during this release");
 						}
@@ -121,9 +121,9 @@ public class StableIdentifierUpdater {
 		stableIdentifierInst.setDisplayName(id + "." + newIdentifierVersion);
 		Collection<GKInstance> modifiedInstances = (Collection<GKInstance>) stableIdentifierInst.getAttributeValuesList(modified);
 		stableIdentifierInst.addAttributeValue(modified, instanceEdit);
-		dba.updateInstanceAttribute(stableIdentifierInst, identifierVersion);
-		dba.updateInstanceAttribute(stableIdentifierInst, _displayName);
-		dba.updateInstanceAttribute(stableIdentifierInst, modified);
+//		dba.updateInstanceAttribute(stableIdentifierInst, identifierVersion);
+//		dba.updateInstanceAttribute(stableIdentifierInst, _displayName);
+//		dba.updateInstanceAttribute(stableIdentifierInst, modified);
 	}
 
 	// Checks via the 'releaseStatus', 'revised', and 'reviewed' attributes if this instance has been updated since last release.

--- a/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
+++ b/src/main/java/org/reactome/release/update_stable_ids/StableIdentifierUpdater.java
@@ -99,11 +99,11 @@ public class StableIdentifierUpdater {
 			}
 		}
 		// TODO: Update test_slice after gkCentral has been successfully updated
-		if (dbaSlice.supportsTransactions()) {
-			dbaSlice.commit();
-		}
+//		if (dbaSlice.supportsTransactions()) {
+//			dbaSlice.commit();
+//		}
 		logger.info("Commiting all changes in " + dbaGkCentral.getDBName());
-		dbaGkCentral.commit();
+//		dbaGkCentral.commit();
 		logger.info(incrementedCount + " Stable Identifiers were updated");
 		logger.info(notIncrementedCount + " were not updated");
 		logger.info("UpdateStableIdentifiers step has finished");


### PR DESCRIPTION
- Removes 'short-cutted' database creation using piped `mysqldump... database1 | mysql... database2` command. This was causing an issue of only partially reconstituting dumped databases. The typical approach, `zcat... dumpFileDatabase1 | mysql... database2` has been implemented. This was an error causing release_previous to not be fully created when trying to reconstitute it directly from release_current
- Moved everything to use shared groovy library
